### PR TITLE
Badgelayout docs

### DIFF
--- a/kivymd_extensions/akivymd/uix/badgelayout.py
+++ b/kivymd_extensions/akivymd/uix/badgelayout.py
@@ -1,11 +1,11 @@
 """
 Components/BadgeLayout
-=======================
+======================
 
 .. rubric:: This layout can be used to add a badge to the top of KivyMD components.
 
 Example
----------------
+-------
 .. code-block:: python
 
     from kivy.lang.builder import Builder
@@ -50,27 +50,27 @@ Builder.load_string(
 <BadgeItem>
     size_hint: None, None
     padding: dp(5)
-    size: self.size if root._text else [dp(20), dp(20)]
-    opacity: 1 if self._badge_disabled == False else 0
+    size: self.size if root.text else [dp(20), dp(20)]
+    opacity: 1 if self.badge_disabled == False else 0
 
     pos:
-        (self.parent.x - self.width * (root._offset), self.parent.y + self.parent.height - self.height * (1 - root._offset)) if root._position == 'left' \
-        else (self.parent.x + self.parent.width - self.width * (1 - root._offset), self.parent.y + self.parent.height - self.height * (1 - root._offset))
+        (self.parent.x - self.width * (root.offset), self.parent.y + self.parent.height - self.height * (1 - root.offset)) if root.position == 'left' \
+        else (self.parent.x + self.parent.width - self.width * (1 - root.offset), self.parent.y + self.parent.height - self.height * (1 - root.offset))
 
     canvas.before:
         Color:
-            rgba: root._bg_color if root._bg_color else root.theme_cls.bg_normal
+            rgba: root.bg_color if root.bg_color else root.theme_cls.bg_normal
         RoundedRectangle:
             pos: self.pos
             size: self.size
             radius: [root.height / 2, ]
 
         Color:
-            rgba: root._badgeitem_color if root._badgeitem_color else root.theme_cls.accent_color
+            rgba: root.badgeitem_color if root.badgeitem_color else root.theme_cls.accent_color
         RoundedRectangle:
             pos:
-                [self.pos[0] + root._badgeitem_padding / 2, self.pos[1] + root._badgeitem_padding/2]
-            size: [self.size[0] - root._badgeitem_padding, self.size[1] - root._badgeitem_padding]
+                [self.pos[0] + root.badgeitem_padding / 2, self.pos[1] + root.badgeitem_padding/2]
+            size: [self.size[0] - root.badgeitem_padding, self.size[1] - root.badgeitem_padding]
             radius: [root.height / 2, ]
     Label:
         size_hint: None, None
@@ -78,9 +78,9 @@ Builder.load_string(
         halign: 'center'
         valign: 'center'
         font_size: dp(13)
-        bold: root._bold
+        bold: root.bold
         pos_hint: {'center_x': .5, 'center_y': .5}
-        text: root._text
+        text: root.text
         color: 1, 1, 1, 1
 
 <AKBadgeLayout>:
@@ -96,31 +96,31 @@ Builder.load_string(
         id: badge
         size_hint: None, None
         size: self.minimum_size
-        _bg_color: root.bg_color
-        _badgeitem_padding: root.badgeitem_padding
-        _badgeitem_color: root.badgeitem_color
-        _position: root.position
-        _text: root.text
-        _bold: root.bold
-        _offset: root.offset
-        _badge_disabled: root.badge_disabled
+        bg_color: root.bg_color
+        badgeitem_padding: root.badgeitem_padding
+        badgeitem_color: root.badgeitem_color
+        position: root.position
+        text: root.text
+        bold: root.bold
+        offset: root.offset
+        badge_disabled: root.badge_disabled
     """
 )
 
+__all__ = ("AKBadgeLayout",)
 
 class BadgeContent(BoxLayout):
     pass
 
-
 class BadgeItem(ThemableBehavior, BoxLayout):
-    _bg_color = ColorProperty()
-    _badgeitem_padding = NumericProperty()
-    _badgeitem_color = ListProperty()
-    _position = OptionProperty("right", options=["right", "left"])
-    _text = StringProperty("")
-    _bold = BooleanProperty()
-    _offset = NumericProperty()
-    _badge_disabled = BooleanProperty(False)
+    bg_color = ColorProperty()
+    badgeitem_padding = NumericProperty()
+    badgeitem_color = ListProperty()
+    position = OptionProperty("right", options=["right", "left"])
+    text = StringProperty("")
+    bold = BooleanProperty()
+    offset = NumericProperty()
+    badge_disabled = BooleanProperty(False)
 
 
 class AKBadgeLayout(FloatLayout):
@@ -130,7 +130,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`bg_color` is an :class:`~kivy.properties.ColorProperty`
     and defaults to `'app.theme_cls.bg_normal'`.
-
     """
 
     badgeitem_padding = NumericProperty(dp(3))
@@ -139,7 +138,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`badgeitem_padding` is an :class:`~kivy.properties.NumericProperty`
     and defaults to `'3dp'`.
-
     """
 
     badgeitem_color = ListProperty()
@@ -148,7 +146,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`badgeitem_color` is an :class:`~kivy.properties.ListProperty`
     and defaults to `'app.theme_cls.accent_color'`.
-
     """
 
     position = OptionProperty("right", options=["right", "left"])
@@ -158,7 +155,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`position` is an :class:`~kivy.properties.OptionProperty`
     and defaults to `'right'`.
-
     """
 
     text = StringProperty("")
@@ -167,7 +163,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`text` is an :class:`~kivy.properties.StringProperty`
     and defaults to `''`.
-
     """
 
     bold = BooleanProperty(False)
@@ -176,7 +171,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`bold` is an :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
-
     """
 
     offset = NumericProperty(0.25)
@@ -185,7 +179,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`offset` is an :class:`~kivy.properties.NumericProperty`
     and defaults to `'0.25'`.
-
     """
 
     badge_disabled = BooleanProperty(False)
@@ -194,7 +187,6 @@ class AKBadgeLayout(FloatLayout):
 
     :attr:`badge_disabled` is an :class:`~kivy.properties.BooleanProperty`
     and defaults to `False`.
-
     """
 
     def add_widget(self, widget, index=0, canvas=None):

--- a/kivymd_extensions/akivymd/uix/badgelayout.py
+++ b/kivymd_extensions/akivymd/uix/badgelayout.py
@@ -1,7 +1,41 @@
+"""
+Components/BadgeLayout
+=======================
+
+.. rubric:: This layout can be used to add a badge to the top of KivyMD components.
+
+Example
+---------------
+.. code-block:: python
+
+    from kivy.lang.builder import Builder
+    from kivymd.app import MDApp
+
+    kv_string = '''
+    AKBadgeLayout:
+        pos_hint: {"center_x": .5, "center_y": .5}
+        badgeitem_padding: dp(5)
+        bold: True
+        text: "233+"
+        offset: .5
+
+        MDRaisedButton:
+            text: "Press"
+    '''
+    class AKBadgeLayout(MDApp):
+        def build(self):
+            return Builder.load_string(kv_string)
+
+    AKBadgeLayout().run()
+
+"""
+
+
 from kivy.lang.builder import Builder
 from kivy.metrics import dp
 from kivy.properties import (
     BooleanProperty,
+    ColorProperty,
     ListProperty,
     NumericProperty,
     OptionProperty,
@@ -16,27 +50,27 @@ Builder.load_string(
 <BadgeItem>
     size_hint: None, None
     padding: dp(5)
-    size: self.size if root.text else [dp(20), dp(20)]
-    opacity: 1 if self.badge_disabled == False else 0
+    size: self.size if root._text else [dp(20), dp(20)]
+    opacity: 1 if self._badge_disabled == False else 0
 
     pos:
-        (self.parent.x - self.width * (root.offset), self.parent.y + self.parent.height - self.height * (1 - root.offset)) if root.position == 'left' \
-        else (self.parent.x + self.parent.width - self.width * (1 - root.offset), self.parent.y + self.parent.height - self.height * (1 - root.offset))
+        (self.parent.x - self.width * (root._offset), self.parent.y + self.parent.height - self.height * (1 - root._offset)) if root._position == 'left' \
+        else (self.parent.x + self.parent.width - self.width * (1 - root._offset), self.parent.y + self.parent.height - self.height * (1 - root._offset))
 
     canvas.before:
         Color:
-            rgba: root.bg_color if root.bg_color else root.theme_cls.bg_normal
+            rgba: root._bg_color if root._bg_color else root.theme_cls.bg_normal
         RoundedRectangle:
             pos: self.pos
             size: self.size
             radius: [root.height / 2, ]
 
         Color:
-            rgba: root.badgeitem_color if root.badgeitem_color else root.theme_cls.accent_color
+            rgba: root._badgeitem_color if root._badgeitem_color else root.theme_cls.accent_color
         RoundedRectangle:
             pos:
-                [self.pos[0] + root.badgeitem_padding / 2, self.pos[1] + root.badgeitem_padding/2]
-            size: [self.size[0] - root.badgeitem_padding, self.size[1] - root.badgeitem_padding]
+                [self.pos[0] + root._badgeitem_padding / 2, self.pos[1] + root._badgeitem_padding/2]
+            size: [self.size[0] - root._badgeitem_padding, self.size[1] - root._badgeitem_padding]
             radius: [root.height / 2, ]
     Label:
         size_hint: None, None
@@ -44,9 +78,9 @@ Builder.load_string(
         halign: 'center'
         valign: 'center'
         font_size: dp(13)
-        bold: root.bold
+        bold: root._bold
         pos_hint: {'center_x': .5, 'center_y': .5}
-        text: root.text
+        text: root._text
         color: 1, 1, 1, 1
 
 <AKBadgeLayout>:
@@ -62,14 +96,14 @@ Builder.load_string(
         id: badge
         size_hint: None, None
         size: self.minimum_size
-        bg_color: root.bg_color
-        badgeitem_padding: root.badgeitem_padding
-        badgeitem_color: root.badgeitem_color
-        position: root.position
-        text: root.text
-        bold: root.bold
-        offset: root.offset
-        badge_disabled: root.badge_disabled
+        _bg_color: root.bg_color
+        _badgeitem_padding: root.badgeitem_padding
+        _badgeitem_color: root.badgeitem_color
+        _position: root.position
+        _text: root.text
+        _bold: root.bold
+        _offset: root.offset
+        _badge_disabled: root.badge_disabled
     """
 )
 
@@ -79,26 +113,89 @@ class BadgeContent(BoxLayout):
 
 
 class BadgeItem(ThemableBehavior, BoxLayout):
-    bg_color = ListProperty()
-    badgeitem_padding = NumericProperty()
-    badgeitem_color = ListProperty()
-    position = OptionProperty("right", options=["right", "left"])
-    text = StringProperty("")
-    bold = BooleanProperty()
-    offset = NumericProperty()
-    badge_disabled = BooleanProperty(False)
+    _bg_color = ColorProperty()
+    _badgeitem_padding = NumericProperty()
+    _badgeitem_color = ListProperty()
+    _position = OptionProperty("right", options=["right", "left"])
+    _text = StringProperty("")
+    _bold = BooleanProperty()
+    _offset = NumericProperty()
+    _badge_disabled = BooleanProperty(False)
 
 
 class AKBadgeLayout(FloatLayout):
-    badgeitem_size = NumericProperty(dp(20))
-    bg_color = ListProperty()
+    bg_color = ColorProperty()
+    """
+    Color of the bakground around a badge.
+
+    :attr:`bg_color` is an :class:`~kivy.properties.ColorProperty`
+    and defaults to `'app.theme_cls.bg_normal'`.
+
+    """
+
     badgeitem_padding = NumericProperty(dp(3))
+    """
+    Padding for the badge.
+
+    :attr:`badgeitem_padding` is an :class:`~kivy.properties.NumericProperty`
+    and defaults to `'3dp'`.
+
+    """
+
     badgeitem_color = ListProperty()
-    position = StringProperty("right")
+    """
+    Color of the badge.
+
+    :attr:`badgeitem_color` is an :class:`~kivy.properties.ListProperty`
+    and defaults to `'app.theme_cls.accent_color'`.
+
+    """
+
+    position = OptionProperty("right", options=["right", "left"])
+    """
+    Position of the badge relative to the widget it is on.
+    Can be set to `right` or `left`.
+
+    :attr:`position` is an :class:`~kivy.properties.OptionProperty`
+    and defaults to `'right'`.
+
+    """
+
     text = StringProperty("")
+    """
+    Text to be placed inside the badge.
+
+    :attr:`text` is an :class:`~kivy.properties.StringProperty`
+    and defaults to `''`.
+
+    """
+
     bold = BooleanProperty(False)
+    """
+    Should the text inside the badge be bold
+
+    :attr:`bold` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+
+    """
+
     offset = NumericProperty(0.25)
+    """
+    Offset of the badge's center point from the corner of the widget it is applied to
+
+    :attr:`offset` is an :class:`~kivy.properties.NumericProperty`
+    and defaults to `'0.25'`.
+
+    """
+
     badge_disabled = BooleanProperty(False)
+    """
+    Show the badge or not. If set to `False` the badge opacity will be set to 0.
+
+    :attr:`badge_disabled` is an :class:`~kivy.properties.BooleanProperty`
+    and defaults to `False`.
+
+    """
 
     def add_widget(self, widget, index=0, canvas=None):
         if issubclass(widget.__class__, BadgeItem) or issubclass(

--- a/kivymd_extensions/akivymd/uix/cardstack.py
+++ b/kivymd_extensions/akivymd/uix/cardstack.py
@@ -13,8 +13,7 @@ Example
     from kivymd.app import MDApp
 
     kv_string = '''
-    <CardStack@MDScreen>:
-
+    FloatLayout:
         AKCardStack:
             id: cardstack
             pos_hint: {"center_x": .5, "center_y": .5}
@@ -26,7 +25,6 @@ Example
             on_press: root.change()
             pos_hint: {"center_x": .5, "y": .05}
     '''
-    )
 
 
     class CardStack(MDApp):


### PR DESCRIPTION
### Description of Changes

- Added docs for badgelayout
- Changed variable names to prevent internal variables from showing up on docs.(doesnt break any older code. All changed names where used internally)
- Removed unused property `badgeitem_size`

If you want I could just keep adding the other widgets documentations to this PR or I could create separate PR's for them?(I prefer separate PR's cause it would help prevent two different people submitting PR of docs for the same widget. But your choice :+1: )
